### PR TITLE
D-42926: Fix argo setup and update images

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,12 @@ If you want to set up the live deployments manually, follow these steps:
 You can manually configure which versions of Release, Deploy and Release Runner to use by editing the `Dockerfile` files of the corresponding services in the
 `docker` directory. Simply change the `FROM` line to point to the desired version of the service.
 
+### xebialabs vs xebialabsunsupported images
+
+The `xebialabs` images are the official releases of the products, while the `xebialabsunsupported` images are built from the latest code in the main branch and
+may contain features and fixes that are not yet available in the official releases. The `xebialabsunsupported` images are intended for testing and development
+purposes and may not be as stable as the `xebialabs` images.
+
 ### Using Release and Deploy from zip
 
 You can use custom versions of Release and Deploy by providing arguments to the `up.sh` script. For example:
@@ -81,10 +87,12 @@ You can use custom versions of Release and Deploy by providing arguments to the 
 
 **Note**: don't forget to add license files to the `xl-deploy-from-zip` and `xl-release-from-zip` folders in the `docker` directory.
 Also, running from zip will most likely not include default plugins, which are only available in distribution packages.
-You can install plugins manually, keep in mind that setup container will fail and will need to be ran again which can be done with this command 
+You can install plugins manually, keep in mind that setup container will fail and will need to be ran again which can be done with this command
+
 ```
 docker container start release-livedeployments-demo-setup-1
 ```
+
 Or run `demo-scenario/setup.yaml` and `demo-scenario/setup-live-deployment.yaml` files manually using `xl apply` command.
 
 ## Running Release Runner in kubernetes

--- a/docker/remote-runner/Dockerfile
+++ b/docker/remote-runner/Dockerfile
@@ -1,4 +1,4 @@
-FROM xebialabsunsupported/release-runner:26.1.0-beta.216
+FROM xebialabs/release-runner:26.1.2-503.130
 
 USER root
 

--- a/docker/xl-deploy/Dockerfile
+++ b/docker/xl-deploy/Dockerfile
@@ -1,4 +1,4 @@
-FROM xebialabsunsupported/xl-deploy:26.1
+FROM xebialabs/xl-deploy:26.1.2-503.130
 
 # Install license
 COPY default-conf/* /opt/xebialabs/xl-deploy-server/default-conf/

--- a/docker/xl-release/Dockerfile
+++ b/docker/xl-release/Dockerfile
@@ -1,4 +1,4 @@
-FROM xebialabsunsupported/xl-release:26.1
+FROM xebialabs/xl-release:26.1.2-503.130
 
 # Install license
 COPY default-conf/* /opt/xebialabs/xl-release-server/default-conf/

--- a/setup/argo/install.cli.md
+++ b/setup/argo/install.cli.md
@@ -25,7 +25,7 @@ Use `kubectl` to install ArgoCD in the `argocd` namespace and create a service a
 
 ```yaml instacli
 Shell: |
-  kubectl apply -n argocd -f https://raw.githubusercontent.com/argoproj/argo-cd/stable/manifests/install.yaml
+  kubectl apply -n argocd --server-side --force-conflicts -f https://raw.githubusercontent.com/argoproj/argo-cd/stable/manifests/install.yaml
 ```
 
 > Waiting for ArgoCD server

--- a/setup/argo/quickstart.cli.md
+++ b/setup/argo/quickstart.cli.md
@@ -55,5 +55,5 @@ Run script: configure-live-deployment.cli.md
 
 ```yaml instacli
 On error:
-  Print: ArgoCD not installed
+  Print: "ArgoCD not installed:\n${error.message}"
 ```

--- a/setup/flux/quickstart.cli.md
+++ b/setup/flux/quickstart.cli.md
@@ -47,5 +47,5 @@ Error handling
 
 ```yaml instacli
 On error:
-  Print: Flux CD not installed
+  Print: "Flux CD not installed:\n${error.message}"
 ```

--- a/setup/k3d/quickstart.cli.md
+++ b/setup/k3d/quickstart.cli.md
@@ -8,5 +8,5 @@ Confirm: Set up K3d?
 Run script: install.cli.md
 
 On error:
-  Print: K3d cluster not installed
+  Print: "K3d cluster not installed:\n${error.message}"
 ```

--- a/up.sh
+++ b/up.sh
@@ -74,7 +74,7 @@ echo "Spinning up Release and Deploy in Docker"
 export RELEASE_DOCKER_PATH=$RELEASE_DOCKER_PATH
 export DEPLOY_DOCKER_PATH=$DEPLOY_DOCKER_PATH
 
-docker compose -f docker-compose.yaml up -d --build || exit 1
+docker compose -f docker-compose.yaml up -d --build --pull always --force-recreate || exit 1
 
 echo "
 Please wait for the Release and Deploy servers to start up.


### PR DESCRIPTION
Update ArgoCD install and docker images that we use. 

Runner freezing will be addressed with different ticket https://www7.v1host.com/V1Production/defect.mvc/Summary?oidToken=Defect%3A3540828 

For now the workaround is to go into runner settings and increase capacity to 50 or restart runner a few times when it gets stuck

Testing:
- [ ] Live Deployments demo repo works
- [ ] WORKAROUND - when deploy task gets frozen go into runner settings and increase capacity to something like 50 and it should complete. Proceed to setup Argo and Flux after the workaround is applied