### PR TITLE
S-135645: auto testing pipeline

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -51,6 +51,8 @@ jobs:
 
       - name: Install FluxCD CLI
         uses: fluxcd/flux2/action@v2.5.1
+        with:
+          version: '2.5.1'
 
       - name: Install Python test dependencies
         run: pip install -r testing/requirements.txt

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -1,4 +1,4 @@
-name: Scheduled E2E Tests
+name: Run tests
 
 # Runs the full demo-stack + UI test suite roughly every two weeks
 # (1st and 15th of the month), plus on-demand via workflow_dispatch.
@@ -10,7 +10,7 @@ on:
   # default branch (schedule/workflow_dispatch only work from the default
   # branch). Remove this trigger once validated.
   pull_request:
-    branches: [main]
+    branches: [ main ]
 
 concurrency:
   group: run-tests-${{ github.event_name == 'pull_request' && github.ref || 'scheduled' }}
@@ -67,7 +67,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: playwright-failure-screenshots
-          path: testing/ui/test-results/**/*.png
+          path: testing/test-results/**/*.png
           if-no-files-found: ignore
           retention-days: 14
 

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -62,12 +62,14 @@ jobs:
         id: run_tests
         run: python testing/run.py --with-ui --cli-setup --down
 
-      - name: Upload failure screenshots
+      - name: Upload failure artifacts
         if: failure()
         uses: actions/upload-artifact@v7
         with:
-          name: playwright-failure-screenshots
-          path: testing/test-results/**/*.png
+          name: failure-artifacts
+          path: |
+            testing/test-results/**/*.png
+            testing/test-results/docker-logs/**
           if-no-files-found: ignore
           retention-days: 14
 

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -1,0 +1,77 @@
+name: Scheduled E2E Tests
+
+# Runs the full demo-stack + UI test suite roughly every two weeks
+# (1st and 15th of the month), plus on-demand via workflow_dispatch.
+on:
+  schedule:
+    - cron: "0 3 1,15 * *"
+  workflow_dispatch: { }
+
+concurrency:
+  group: run-tests
+  cancel-in-progress: false
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Java (required by ./cli / Instacli)
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "21"
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: testing/requirements.txt
+
+      - name: Set up Docker Buildx (ensures docker compose v2 plugin is ready)
+        uses: docker/setup-buildx-action@v3
+
+      - name: Install kubectl
+        uses: azure/setup-kubectl@v4
+        with:
+          version: latest
+
+      - name: Install k3d
+        run: curl -s https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | bash
+
+      - name: Install FluxCD CLI
+        uses: fluxcd/flux2/action@main
+
+      - name: Install Python test dependencies
+        run: pip install -r testing/requirements.txt
+
+      - name: Install Playwright browsers
+        run: python -m playwright install --with-deps
+
+      - name: Run E2E test suite
+        id: run_tests
+        run: python testing/run.py --with-ui --cli-setup --down
+
+      - name: Upload failure screenshots
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-failure-screenshots
+          path: testing/ui/test-results/**/*.png
+          if-no-files-found: ignore
+          retention-days: 14
+
+      - name: Send Slack notification
+        if: always() && secrets.SLACK_BOT_TOKEN != '' && secrets.SLACK_CHANNEL_ID != ''
+        uses: slackapi/slack-github-action@v2.0.0
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          payload: |
+            channel: ${{ secrets.SLACK_CHANNEL_ID }}
+            text: "${{ job.status == 'success' && ':white_check_mark:' || ':x:' }} Live Deployments Demo Repo tests *${{ job.status }}* (run <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|#${{ github.run_number }}>)"

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -23,26 +23,26 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Java (required by ./cli / Instacli)
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: "21"
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: "3.12"
           cache: pip
           cache-dependency-path: testing/requirements.txt
 
       - name: Set up Docker Buildx (ensures docker compose v2 plugin is ready)
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Install kubectl
-        uses: azure/setup-kubectl@v4
+        uses: azure/setup-kubectl@v5
         with:
           version: latest
 
@@ -50,7 +50,7 @@ jobs:
         run: curl -s https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | bash
 
       - name: Install FluxCD CLI
-        uses: fluxcd/flux2/action@main
+        uses: fluxcd/flux2/action@v2.9.3
 
       - name: Install Python test dependencies
         run: pip install -r testing/requirements.txt
@@ -64,7 +64,7 @@ jobs:
 
       - name: Upload failure screenshots
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: playwright-failure-screenshots
           path: testing/test-results/**/*.png
@@ -76,7 +76,7 @@ jobs:
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
           SLACK_CHANNEL_ID: ${{ secrets.SLACK_CHANNEL_ID }}
-        uses: slackapi/slack-github-action@v2.0.0
+        uses: slackapi/slack-github-action@v4.0.0
         with:
           method: chat.postMessage
           token: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -6,10 +6,15 @@ on:
   schedule:
     - cron: "0 3 1,15 * *"
   workflow_dispatch: { }
+  # TEMPORARY: lets us validate the workflow on this PR before merging to the
+  # default branch (schedule/workflow_dispatch only work from the default
+  # branch). Remove this trigger once validated.
+  pull_request:
+    branches: [main]
 
 concurrency:
-  group: run-tests
-  cancel-in-progress: false
+  group: run-tests-${{ github.event_name == 'pull_request' && github.ref || 'scheduled' }}
+  cancel-in-progress: true
 
 jobs:
   e2e:

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -50,7 +50,7 @@ jobs:
         run: curl -s https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | bash
 
       - name: Install FluxCD CLI
-        uses: fluxcd/flux2/action@v2.9.3
+        uses: fluxcd/flux2/action@v2.5.1
 
       - name: Install Python test dependencies
         run: pip install -r testing/requirements.txt

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -6,11 +6,6 @@ on:
   schedule:
     - cron: "0 3 1,15 * *"
   workflow_dispatch: { }
-  # TEMPORARY: lets us validate the workflow on this PR before merging to the
-  # default branch (schedule/workflow_dispatch only work from the default
-  # branch). Remove this trigger once validated.
-  pull_request:
-    branches: [ main ]
 
 concurrency:
   group: run-tests-${{ github.event_name == 'pull_request' && github.ref || 'scheduled' }}

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -67,7 +67,10 @@ jobs:
           retention-days: 14
 
       - name: Send Slack notification
-        if: always() && secrets.SLACK_BOT_TOKEN != '' && secrets.SLACK_CHANNEL_ID != ''
+        if: always() && env.SLACK_BOT_TOKEN != '' && env.SLACK_CHANNEL_ID != ''
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          SLACK_CHANNEL_ID: ${{ secrets.SLACK_CHANNEL_ID }}
         uses: slackapi/slack-github-action@v2.0.0
         with:
           method: chat.postMessage

--- a/setup/k3d/install.cli.md
+++ b/setup/k3d/install.cli.md
@@ -24,6 +24,7 @@ Shell: |
 
 ```yaml instacli
 Shell: |
+  sleep 15
   kubectl wait --for=condition=Ready pod -l k8s-app=metrics-server -n kube-system --timeout=300s
 ```
 

--- a/testing/framework/docker_env.py
+++ b/testing/framework/docker_env.py
@@ -189,24 +189,23 @@ def dump_relevant_container_logs(output_dir: Path) -> List[Path]:
     output_dir.mkdir(parents=True, exist_ok=True)
 
     names_result = subprocess.run(
-        [
-            "docker",
-            "ps",
-            "-a",
-            "--filter",
-            "network=demo-network",
-            "--format",
-            "{{.Names}}",
-        ],
+        ["docker", "ps", "-a", "--format", "{{.Names}}"],
         capture_output=True,
         text=True,
         check=False,
     )
-    relevant_names = [
-        name
-        for name in names_result.stdout.splitlines()
-        if name and not name.startswith("k3d-")
-    ]
+    relevant_names = []
+    for name in names_result.stdout.splitlines():
+        if not name or name.startswith("k3d-"):
+            continue
+        networks_result = subprocess.run(
+            ["docker", "inspect", "-f", "{{json .NetworkSettings.Networks}}", name],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if "demo-network" in networks_result.stdout:
+            relevant_names.append(name)
 
     written_files: List[Path] = []
     for name in relevant_names:

--- a/testing/framework/docker_env.py
+++ b/testing/framework/docker_env.py
@@ -189,23 +189,24 @@ def dump_relevant_container_logs(output_dir: Path) -> List[Path]:
     output_dir.mkdir(parents=True, exist_ok=True)
 
     names_result = subprocess.run(
-        ["docker", "ps", "-a", "--format", "{{.Names}}"],
+        [
+            "docker",
+            "ps",
+            "-a",
+            "--filter",
+            "network=demo-network",
+            "--format",
+            "{{.Names}}",
+        ],
         capture_output=True,
         text=True,
         check=False,
     )
-    relevant_names = []
-    for name in names_result.stdout.splitlines():
-        if not name or name.startswith("k3d-"):
-            continue
-        networks_result = subprocess.run(
-            ["docker", "inspect", "-f", "{{json .NetworkSettings.Networks}}", name],
-            capture_output=True,
-            text=True,
-            check=False,
-        )
-        if "demo-network" in networks_result.stdout:
-            relevant_names.append(name)
+    relevant_names = [
+        name
+        for name in names_result.stdout.splitlines()
+        if name and not name.startswith("k3d-")
+    ]
 
     written_files: List[Path] = []
     for name in relevant_names:

--- a/testing/framework/docker_env.py
+++ b/testing/framework/docker_env.py
@@ -129,6 +129,42 @@ def check_http_ready(url: str, timeout: int = config.HTTP_TIMEOUT) -> bool:
         return False
 
 
+def get_all_container_statuses(repo_root: Path) -> str:
+    sections: List[str] = []
+
+    compose_ps = subprocess.run(
+        [
+            "docker",
+            "compose",
+            "-f",
+            _compose_file(repo_root),
+            "ps",
+            "-a",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+        env=_compose_env(),
+    )
+    sections.append("$ docker compose ps -a\n" + compose_ps.stdout + compose_ps.stderr)
+
+    all_containers = subprocess.run(
+        [
+            "docker",
+            "ps",
+            "-a",
+            "--format",
+            "table {{.Names}}\t{{.Image}}\t{{.Status}}\t{{.Ports}}",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    sections.append("$ docker ps -a\n" + all_containers.stdout + all_containers.stderr)
+
+    return "\n".join(sections)
+
+
 def get_service_logs(repo_root: Path, service: str, tail: int = 50) -> str:
     result = subprocess.run(
         [

--- a/testing/framework/docker_env.py
+++ b/testing/framework/docker_env.py
@@ -185,6 +185,44 @@ def get_service_logs(repo_root: Path, service: str, tail: int = 50) -> str:
     return result.stdout + result.stderr
 
 
+def dump_relevant_container_logs(output_dir: Path) -> List[Path]:
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    names_result = subprocess.run(
+        [
+            "docker",
+            "ps",
+            "-a",
+            "--filter",
+            "network=demo-network",
+            "--format",
+            "{{.Names}}",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    relevant_names = [
+        name
+        for name in names_result.stdout.splitlines()
+        if name and not name.startswith("k3d-")
+    ]
+
+    written_files: List[Path] = []
+    for name in relevant_names:
+        logs_result = subprocess.run(
+            ["docker", "logs", "--timestamps", name],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        log_file = output_dir / f"{name}.log"
+        log_file.write_text(logs_result.stdout + logs_result.stderr)
+        written_files.append(log_file)
+
+    return written_files
+
+
 def wait_for_stack_ready(
     repo_root: Path,
     timeout: int = config.DEFAULT_TIMEOUT,

--- a/testing/framework/docker_env.py
+++ b/testing/framework/docker_env.py
@@ -202,11 +202,10 @@ def dump_relevant_container_logs(output_dir: Path) -> List[Path]:
         text=True,
         check=False,
     )
-    relevant_names = [
-        name
-        for name in names_result.stdout.splitlines()
-        if name and not name.startswith("k3d-")
-    ]
+    relevant_names = []
+    for name in names_result.stdout.splitlines():
+        if name and not name.startswith("k3d-"):
+            relevant_names.append(name)
 
     written_files: List[Path] = []
     for name in relevant_names:

--- a/testing/framework/kubernetes_util.py
+++ b/testing/framework/kubernetes_util.py
@@ -37,24 +37,3 @@ def wait_for_app_ready(
         check=False,
     )
     return result.returncode == 0
-
-
-def force_fluxcd_reconcile(
-    kustomization: str = "podinfo", namespace: str = "podinfo", timeout: int = 60
-) -> bool:
-    result = subprocess.run(
-        [
-            "flux",
-            "reconcile",
-            "kustomization",
-            kustomization,
-            "-n",
-            namespace,
-            "--with-source",
-            f"--timeout={timeout}s",
-        ],
-        capture_output=True,
-        text=True,
-        check=False,
-    )
-    return result.returncode == 0

--- a/testing/framework/kubernetes_util.py
+++ b/testing/framework/kubernetes_util.py
@@ -1,15 +1,33 @@
 import subprocess
+from typing import List
 
 
-def wait_for_app_condition(
-    app_name: str, namespace: str, condition: str = "available", timeout: int = 180
+def _run_diagnostic_command(cmd: List[str]) -> str:
+    result = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    output = (result.stdout or "") + (result.stderr or "")
+    return f"$ {' '.join(cmd)}\n{output}"
+
+
+def get_cluster_diagnostics() -> str:
+    commands: List[List[str]] = [
+        ["k3d", "cluster", "list"],
+        ["kubectl", "get", "all", "-A", "-o", "wide"],
+        ["kubectl", "get", "events", "-A", "--sort-by=.lastTimestamp"],
+    ]
+    return "\n\n".join(_run_diagnostic_command(cmd) for cmd in commands)
+
+
+def wait_for_app_ready(
+    resource: str,
+    namespace: str,
+    timeout: int = 180,
 ) -> bool:
     result = subprocess.run(
         [
             "kubectl",
-            "wait",
-            f"--for=condition={condition}",
-            app_name,
+            "rollout",
+            "status",
+            resource,
             "-n",
             namespace,
             f"--timeout={timeout}s",

--- a/testing/framework/kubernetes_util.py
+++ b/testing/framework/kubernetes_util.py
@@ -37,3 +37,24 @@ def wait_for_app_ready(
         check=False,
     )
     return result.returncode == 0
+
+
+def force_fluxcd_reconcile(
+    kustomization: str = "podinfo", namespace: str = "podinfo", timeout: int = 60
+) -> bool:
+    result = subprocess.run(
+        [
+            "flux",
+            "reconcile",
+            "kustomization",
+            kustomization,
+            "-n",
+            namespace,
+            "--with-source",
+            f"--timeout={timeout}s",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return result.returncode == 0

--- a/testing/run.py
+++ b/testing/run.py
@@ -9,7 +9,6 @@ from typing import List, Optional
 
 from framework import config, docker_env
 from framework.kubernetes_util import (
-    force_fluxcd_reconcile,
     get_cluster_diagnostics,
     wait_for_app_ready,
 )

--- a/testing/run.py
+++ b/testing/run.py
@@ -8,7 +8,11 @@ from pathlib import Path
 from typing import List, Optional
 
 from framework import config, docker_env
-from framework.kubernetes_util import get_cluster_diagnostics, wait_for_app_ready
+from framework.kubernetes_util import (
+    force_fluxcd_reconcile,
+    get_cluster_diagnostics,
+    wait_for_app_ready,
+)
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 TESTING_DIR = Path(__file__).resolve().parent
@@ -192,6 +196,12 @@ def wait_for_apps_ready() -> None:
         )
 
 
+def phase_force_fluxcd_reconcile() -> None:
+    if not force_fluxcd_reconcile(kustomization="podinfo", namespace="podinfo"):
+        _print_cluster_diagnostics()
+        raise PhaseFailedError("Failed to force FluxCD reconcile for 'podinfo'.")
+
+
 def phase_cli_delete() -> None:
     cmd = ["bash", "./cli", "-q", "setup", "k3d", "delete"]
 
@@ -235,6 +245,8 @@ def main() -> None:
             phase_cli_setup()
             log_banner("Waiting for apps to become ready")
             wait_for_apps_ready()
+            log_banner("Forcing FluxCD reconcile")
+            phase_force_fluxcd_reconcile()
         else:
             print("--cli-setup not given, skipping cluster setup.")
 

--- a/testing/run.py
+++ b/testing/run.py
@@ -16,6 +16,7 @@ from framework.kubernetes_util import (
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 TESTING_DIR = Path(__file__).resolve().parent
+DOCKER_LOGS_DIR = TESTING_DIR / "test-results" / "docker-logs"
 PYTEST_PHASE_ONE_COMMAND = [
     sys.executable,
     "-m",
@@ -111,9 +112,11 @@ def phase_readiness(timeout: int) -> None:
         print("Stack is ready: all services running and Release/Deploy responding.")
     except docker_env.ServiceFailedError as exc:
         _print_service_logs(exc.service)
+        _dump_docker_logs()
         raise PhaseFailedError(str(exc)) from exc
     except TimeoutError as exc:
         _print_service_logs(config.SETUP_SERVICE)
+        _dump_docker_logs()
         raise PhaseFailedError(f"Timed out waiting for stack readiness: {exc}") from exc
 
 
@@ -145,6 +148,20 @@ def _print_cluster_diagnostics() -> None:
     print("--- end of Kubernetes cluster state ---\n", file=sys.stderr)
 
 
+def _dump_docker_logs() -> None:
+    print(
+        f"\n--- Dumping relevant docker container logs to {DOCKER_LOGS_DIR} ---",
+        file=sys.stderr,
+    )
+    try:
+        written_files = docker_env.dump_relevant_container_logs(DOCKER_LOGS_DIR)
+        for log_file in written_files:
+            print(f"  wrote {log_file}", file=sys.stderr)
+    except Exception as exc:
+        print(f"(failed to dump docker container logs: {exc})", file=sys.stderr)
+    print("--- end of docker container logs dump ---\n", file=sys.stderr)
+
+
 def __ui_tests(test_command: List[str]) -> None:
     env = os.environ.copy()
     env.setdefault("RELEASE_URL", config.RELEASE_URL)
@@ -162,6 +179,7 @@ def phase_one_ui_tests() -> None:
         __ui_tests(PYTEST_PHASE_ONE_COMMAND)
     except PhaseFailedError:
         _print_docker_diagnostics()
+        _dump_docker_logs()
         raise
 
 
@@ -171,6 +189,7 @@ def phase_two_ui_tests() -> None:
     except PhaseFailedError:
         _print_docker_diagnostics()
         _print_cluster_diagnostics()
+        _dump_docker_logs()
         raise
 
 
@@ -180,6 +199,7 @@ def phase_cli_setup() -> None:
     exit_code = run_streaming(cmd, cwd=REPO_ROOT)
     if exit_code != 0:
         _print_cluster_diagnostics()
+        _dump_docker_logs()
         raise PhaseFailedError(f"cli setup failed with exit code {exit_code}.")
 
 
@@ -191,6 +211,7 @@ def wait_for_apps_ready() -> None:
     flux_result = wait_for_app_ready(resource="deployment/podinfo", namespace="podinfo")
     if not argo_result or not flux_result:
         _print_cluster_diagnostics()
+        _dump_docker_logs()
         raise PhaseFailedError(
             f"demo apps are not available in cluster. ArgoCD: {argo_result}, FluxCD: {flux_result}"
         )
@@ -199,6 +220,7 @@ def wait_for_apps_ready() -> None:
 def phase_force_fluxcd_reconcile() -> None:
     if not force_fluxcd_reconcile(kustomization="podinfo", namespace="podinfo"):
         _print_cluster_diagnostics()
+        _dump_docker_logs()
         raise PhaseFailedError("Failed to force FluxCD reconcile for 'podinfo'.")
 
 

--- a/testing/run.py
+++ b/testing/run.py
@@ -216,13 +216,6 @@ def wait_for_apps_ready() -> None:
         )
 
 
-def phase_force_fluxcd_reconcile() -> None:
-    if not force_fluxcd_reconcile(kustomization="podinfo", namespace="podinfo"):
-        _print_cluster_diagnostics()
-        _dump_docker_logs()
-        raise PhaseFailedError("Failed to force FluxCD reconcile for 'podinfo'.")
-
-
 def phase_cli_delete() -> None:
     cmd = ["bash", "./cli", "-q", "setup", "k3d", "delete"]
 
@@ -266,8 +259,6 @@ def main() -> None:
             phase_cli_setup()
             log_banner("Waiting for apps to become ready")
             wait_for_apps_ready()
-            log_banner("Forcing FluxCD reconcile")
-            phase_force_fluxcd_reconcile()
         else:
             print("--cli-setup not given, skipping cluster setup.")
 

--- a/testing/run.py
+++ b/testing/run.py
@@ -150,7 +150,8 @@ def _print_cluster_diagnostics() -> None:
 
 def _dump_docker_logs() -> None:
     print(
-        f"\n--- Dumping docker container logs to {DOCKER_LOGS_DIR} ---", file=sys.stderr
+        f"\n--- Dumping relevant docker container logs to {DOCKER_LOGS_DIR} ---",
+        file=sys.stderr,
     )
     try:
         written_files = docker_env.dump_relevant_container_logs(DOCKER_LOGS_DIR)

--- a/testing/run.py
+++ b/testing/run.py
@@ -150,8 +150,7 @@ def _print_cluster_diagnostics() -> None:
 
 def _dump_docker_logs() -> None:
     print(
-        f"\n--- Dumping relevant docker container logs to {DOCKER_LOGS_DIR} ---",
-        file=sys.stderr,
+        f"\n--- Dumping docker container logs to {DOCKER_LOGS_DIR} ---", file=sys.stderr
     )
     try:
         written_files = docker_env.dump_relevant_container_logs(DOCKER_LOGS_DIR)

--- a/testing/run.py
+++ b/testing/run.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from typing import List, Optional
 
 from framework import config, docker_env
-from framework.kubernetes_util import wait_for_app_condition
+from framework.kubernetes_util import get_cluster_diagnostics, wait_for_app_ready
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 TESTING_DIR = Path(__file__).resolve().parent
@@ -123,6 +123,24 @@ def _print_service_logs(service: str) -> None:
     print("--- end of logs ---\n", file=sys.stderr)
 
 
+def _print_docker_diagnostics() -> None:
+    print("\n--- Docker container statuses ---", file=sys.stderr)
+    try:
+        print(docker_env.get_all_container_statuses(REPO_ROOT), file=sys.stderr)
+    except Exception as exc:
+        print(f"(failed to fetch docker container statuses: {exc})", file=sys.stderr)
+    print("--- end of docker container statuses ---\n", file=sys.stderr)
+
+
+def _print_cluster_diagnostics() -> None:
+    print("\n--- Kubernetes cluster state ---", file=sys.stderr)
+    try:
+        print(get_cluster_diagnostics(), file=sys.stderr)
+    except Exception as exc:
+        print(f"(failed to fetch cluster diagnostics: {exc})", file=sys.stderr)
+    print("--- end of Kubernetes cluster state ---\n", file=sys.stderr)
+
+
 def __ui_tests(test_command: List[str]) -> None:
     env = os.environ.copy()
     env.setdefault("RELEASE_URL", config.RELEASE_URL)
@@ -136,11 +154,20 @@ def __ui_tests(test_command: List[str]) -> None:
 
 
 def phase_one_ui_tests() -> None:
-    __ui_tests(PYTEST_PHASE_ONE_COMMAND)
+    try:
+        __ui_tests(PYTEST_PHASE_ONE_COMMAND)
+    except PhaseFailedError:
+        _print_docker_diagnostics()
+        raise
 
 
 def phase_two_ui_tests() -> None:
-    __ui_tests(PYTEST_PHASE_TWO_COMMAND)
+    try:
+        __ui_tests(PYTEST_PHASE_TWO_COMMAND)
+    except PhaseFailedError:
+        _print_docker_diagnostics()
+        _print_cluster_diagnostics()
+        raise
 
 
 def phase_cli_setup() -> None:
@@ -148,18 +175,18 @@ def phase_cli_setup() -> None:
 
     exit_code = run_streaming(cmd, cwd=REPO_ROOT)
     if exit_code != 0:
+        _print_cluster_diagnostics()
         raise PhaseFailedError(f"cli setup failed with exit code {exit_code}.")
 
 
 # cli setup does not wait for apps to become ready, for testing we need to wait for apps so that deployments are created
-def wait_for_apps_available() -> None:
-    argo_result = wait_for_app_condition(
-        app_name="deployment/kustomize-guestbook-ui", namespace="guestbook"
+def wait_for_apps_ready() -> None:
+    argo_result = wait_for_app_ready(
+        resource="deployment/kustomize-guestbook-ui", namespace="guestbook"
     )
-    flux_result = wait_for_app_condition(
-        app_name="deployment/podinfo", namespace="podinfo"
-    )
+    flux_result = wait_for_app_ready(resource="deployment/podinfo", namespace="podinfo")
     if not argo_result or not flux_result:
+        _print_cluster_diagnostics()
         raise PhaseFailedError(
             f"demo apps are not available in cluster. ArgoCD: {argo_result}, FluxCD: {flux_result}"
         )
@@ -206,8 +233,8 @@ def main() -> None:
         log_banner("Phase: cli-setup cluster setup")
         if args.cli_setup:
             phase_cli_setup()
-            log_banner("Waiting for apps to become available")
-            wait_for_apps_available()
+            log_banner("Waiting for apps to become ready")
+            wait_for_apps_ready()
         else:
             print("--cli-setup not given, skipping cluster setup.")
 

--- a/testing/ui/conftest.py
+++ b/testing/ui/conftest.py
@@ -2,7 +2,7 @@ import os
 from typing import Iterator
 
 import pytest
-from playwright.sync_api import Browser, Page
+from playwright.sync_api import Browser, Page, ViewportSize
 
 from pages.login_page import LoginPage
 
@@ -33,7 +33,9 @@ def authenticated_page(
 ) -> Iterator[Page]:
     """One shared, already-logged-in page reused by every test in the session."""
     release_url = os.environ.get("RELEASE_URL", "http://localhost:5516")
-    context = browser.new_context(base_url=release_url)
+    context = browser.new_context(
+        base_url=release_url, viewport=ViewportSize(width=1920, height=1080)
+    )
     page = context.new_page()
 
     LoginPage(page).login(admin_username, admin_password)

--- a/testing/ui/pages/connections_page.py
+++ b/testing/ui/pages/connections_page.py
@@ -1,0 +1,31 @@
+from playwright.sync_api import expect
+
+from pages.base_page import BasePage
+
+
+class ConnectionsPage(BasePage):
+    def open(self) -> "ConnectionsPage":
+        self.page.goto("./#/configuration")
+        expect(
+            self.page.get_by_label("breadcrumb").get_by_text("Connections")
+        ).to_be_visible()
+        return self
+
+    def open_instance(self, instance_name: str) -> "ConnectionsPage":
+        expect(self.page.locator("#configuration")).to_be_visible(timeout=200_000)
+        instance = self.page.locator(".configuration-instance").filter(
+            has_text=instance_name
+        )
+        expect(instance).to_be_visible()
+        instance.locator(".edit-instance").click(force=True)
+        return self
+
+    def test_connection(self) -> "ConnectionsPage":
+        self.page.get_by_role("button", name="Test").click()
+        return self
+
+    def expect_result_banner(self, message: str) -> "ConnectionsPage":
+        banner = self.page.locator(".configuration-result-banner")
+        expect(banner).to_be_visible(timeout=120_000)
+        expect(banner).to_contain_text(message)
+        return self

--- a/testing/ui/pages/live_deployments_page.py
+++ b/testing/ui/pages/live_deployments_page.py
@@ -1,6 +1,7 @@
-from playwright.sync_api import expect
+import time
 
-from framework.test_util import is_visible_with_reload
+from playwright.sync_api import Locator, expect
+
 from pages.base_page import BasePage
 
 
@@ -19,6 +20,24 @@ class LiveDeploymentsPage(BasePage):
         ).not_to_be_visible(timeout=30_000)
         return self
 
+    def _is_visible_with_refresh(
+        self, locator: Locator, timeout: int = 120, interval: int = 20
+    ) -> None:
+        refresh_button = self.page.locator("button.sync-btn")
+        start_time = time.time()
+
+        while time.time() - start_time < timeout:
+            if locator.first.is_visible():
+                return
+
+            refresh_button.click()
+            self.wait_for_live_deployments_loaded()
+            time.sleep(interval)
+
+        assert (
+            False
+        ), f"Timeout: Locator '{locator}' did not become visible after {timeout}s"
+
     def expect_live_deployment_displayed(
         self, deployment_name: str
     ) -> "LiveDeploymentsPage":
@@ -28,9 +47,7 @@ class LiveDeploymentsPage(BasePage):
             .first
         )
         # some deployments take a while to show up
-        is_visible_with_reload(
-            page=self.page, locator=deployment_card, timeout=120, interval=20
-        )
+        self._is_visible_with_refresh(locator=deployment_card, timeout=120, interval=20)
         return self
 
     def expect_live_deployment_count(
@@ -40,8 +57,6 @@ class LiveDeploymentsPage(BasePage):
             has_text=deployment_name
         )
         # some deployments take a while to show up
-        is_visible_with_reload(
-            page=self.page, locator=deployments, timeout=120, interval=20
-        )
+        self._is_visible_with_refresh(locator=deployments, timeout=120, interval=20)
         expect(deployments).to_have_count(count)
         return self

--- a/testing/ui/tests/test_connections.py
+++ b/testing/ui/tests/test_connections.py
@@ -1,0 +1,42 @@
+import pytest
+from playwright.sync_api import Page
+
+from pages.connections_page import ConnectionsPage
+
+
+@pytest.mark.phase_one
+def test_deploy_connection(authenticated_page: Page) -> None:
+    connections_page = ConnectionsPage(authenticated_page)
+    connections_page.open()
+    connections_page.open_instance("Local Deploy (Docker)")
+    connections_page.test_connection()
+    connections_page.expect_result_banner(
+        "Digital.ai Deploy Server (Container) is available"
+    )
+
+
+@pytest.mark.phase_two
+def test_kubernetes_connection(authenticated_page: Page) -> None:
+    connections_page = ConnectionsPage(authenticated_page)
+    connections_page.open()
+    connections_page.open_instance("Kubernetes Server Connection")
+    connections_page.test_connection()
+    connections_page.expect_result_banner("Kubernetes API Server (Container)")
+
+
+@pytest.mark.phase_two
+def test_argocd_connection(authenticated_page: Page) -> None:
+    connections_page = ConnectionsPage(authenticated_page)
+    connections_page.open()
+    connections_page.open_instance("ArgoCD Server Connection")
+    connections_page.test_connection()
+    connections_page.expect_result_banner("ArgoCD API Server (Container) is available")
+
+
+@pytest.mark.phase_two
+def test_fluxcd_connection(authenticated_page: Page) -> None:
+    connections_page = ConnectionsPage(authenticated_page)
+    connections_page.open()
+    connections_page.open_instance("FluxCD Server Connection")
+    connections_page.test_connection()
+    connections_page.expect_result_banner("FluxCD API Server (Container) is available")

--- a/testing/ui/tests/test_releases.py
+++ b/testing/ui/tests/test_releases.py
@@ -1,7 +1,10 @@
+import os
+
 import pytest
 from playwright.sync_api import Page
 
 from pages.releases_list_page import ReleasesListPage
+
 
 # order(1) - Run release tests first as they make sure that everything was created for other tests
 
@@ -37,3 +40,6 @@ def test_fluxcd_releases_created(authenticated_page: Page) -> None:
     releases_page.clear_all_filters()
     releases_page.expect_release_displayed("Add FluxCD Live Deployments")
     releases_page.expect_release_completed("Add FluxCD Live Deployments")
+    output_path = os.path.join("test-results", "test_fluxcd_releases_created")
+    os.makedirs(output_path, exist_ok=True)
+    authenticated_page.screenshot(path=os.path.join(output_path, "test-failed.png"))

--- a/testing/ui/tests/test_releases.py
+++ b/testing/ui/tests/test_releases.py
@@ -1,5 +1,3 @@
-import os
-
 import pytest
 from playwright.sync_api import Page
 
@@ -40,6 +38,3 @@ def test_fluxcd_releases_created(authenticated_page: Page) -> None:
     releases_page.clear_all_filters()
     releases_page.expect_release_displayed("Add FluxCD Live Deployments")
     releases_page.expect_release_completed("Add FluxCD Live Deployments")
-    output_path = os.path.join("test-results", "test_fluxcd_releases_created")
-    os.makedirs(output_path, exist_ok=True)
-    authenticated_page.screenshot(path=os.path.join(output_path, "test-failed.png"))


### PR DESCRIPTION
Add CI that is invoked every 2 weeks (on 1st and 15th days). CI will run all the testing that was created in stage 1. It will also report results to `team-mario` slack channel for visibility.
The testing was updated further, on failure it now will print the full state of containers and cluster. It will also add all the logs from all instances to the zip file for downloading